### PR TITLE
Moved graphQL to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "author": "Alek Barszczewski <alek.barszczewski@gmail.com>",
   "license": "ISC",
+  "peerDependencies": {
+    "graphql": "^0.13.1"
+  },
   "dependencies": {
-    "graphql": "^0.13.1",
     "graphql-tools": "^2.21.0",
     "koa-compose": "^3.2.1"
   },


### PR DESCRIPTION
graphQL does not support multiple instances of the module being present in a single project. other graphQL related modules resolve this by including it as a peerDependency instead of a normal dependency.