### PR TITLE
Prevent double execution of middleware

### DIFF
--- a/src/graphql-add-middleware.js
+++ b/src/graphql-add-middleware.js
@@ -52,8 +52,9 @@ export function addMiddleware (schema, path, fn) {
     schema.getMutationType(),
     schema.getSubscriptionType(),
   ]).filter(x => !!x);
+  let middlewaredTypes = {};
   rootTypes.forEach((type) => {
-    addMiddlewareToType(type, fn, { parentType, parentField });
+    middlewaredTypes = addMiddlewareToType(type, fn, { parentType, parentField, middlewaredTypes });
   });
 };
 
@@ -66,7 +67,7 @@ const addMiddlewareToType = function (type, fn, {
   if (type && type.name && middlewaredTypes[type.name]) {
     // Stop going into recursion with adding middlewares
     // on recursive types
-    return;
+    return middlewaredTypes;
   } else {
     middlewaredTypes[type.name] = true;
   }
@@ -88,4 +89,6 @@ const addMiddlewareToType = function (type, fn, {
       });
     }
   });
+
+  return middlewaredTypes;
 }


### PR DESCRIPTION
Hey @alekbarszczewski!

This patch ensures a middleware gets added to a non-root type only once, regardless of how many times it appears on root types.

Without this change, a middleware added to a type that appears both on a `Query` and a `Mutation` ends up being executed twice.

What do you think?